### PR TITLE
ci: workflow for publishing gpu images and zarf packages

### DIFF
--- a/.github/workflows/release-gpu-artifacts.yaml
+++ b/.github/workflows/release-gpu-artifacts.yaml
@@ -1,0 +1,40 @@
+name: Release GPU Artifact
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  push-release-amd64:
+    runs-on: ai-ubuntu-big-boy-4-core
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Disable shallow clone
+        run: git fetch --unshallow
+
+      - name: Set VERSION
+        run: echo "VERSION=$(git describe --abbrev=0 --tags | sed -e 's/^v//')" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images
+        run: |
+          make docker-build-gpu VERSION=$VERSION ARCH=amd64
+          make docker-push-gpu VERSION=$VERSION ARCH=amd64
+
+      - name: Install Zarf
+        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
+
+      - name: Build Zarf Package
+        run: zarf package create . --set=IMAGE_VERSION=$VERSION --set=NAME=llama-cpp-python-gpu --set="IMAGE_REPOSITORY=ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python" --confirm
+
+      - name: Publish Zarf Package
+        run: zarf package publish zarf-package-*.zst oci://ghcr.io/defenseunicorns/packages

--- a/.github/workflows/release-gpu-artifacts.yaml
+++ b/.github/workflows/release-gpu-artifacts.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Push images
         run: |
-          make docker-build-gpu VERSION=$VERSION ARCH=amd64
-          make docker-push-gpu VERSION=$VERSION ARCH=amd64
+          make docker-build-gpu VERSION=$VERSION
+          make docker-push-gpu VERSION=$VERSION
 
       - name: Install Zarf
         uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,4 @@ docker-push:
 	docker push ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python:${VERSION}-${ARCH}
 
 docker-push-gpu:
-	docker push ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python-gpu:${VERSION}-${ARCH}
+	docker push ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python-gpu:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docker-build:
 
 docker-build-gpu:
 	if ! [ -f config.yaml ]; then cp config.example.yaml config.yaml; fi
-	docker build -f Dockerfile.gpu -t ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python-gpu:${VERSION}-${ARCH} . --build-arg ARCH=${ARCH}
+	docker build -f Dockerfile.gpu -t ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python-gpu:${VERSION} .
 
 docker-run:
 	docker run -d -p 50051:50051 ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python:${VERSION}-${ARCH}


### PR DESCRIPTION
We now have access to larger runners so we can finally be better about how we publish artifacts.

This PR adds a workflow for building the Dockerfile.gpu image, publishing the created image, and then using the newly published image to build a zarf package and then, finally, publishing the newly created zarf package.