### PR TITLE
ci: Add workflow for running e2e tests w/ llamacpp

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,4 +56,4 @@ jobs:
 
         - name: Run Tests
           run: |
-            python -m pytest . -v
+            python -m pytest ./tests/e2e -v

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,60 @@
+name: e2e
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "CODEOWNERS"
+      - ".gitignore"
+      - "docs/**"
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # runs-on: ai-ubuntu-big-boy-8-core
+    runs-on: ubuntu-latest
+     
+    steps:
+        - name: Checkout Repo
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+        - name: Setup Python
+          uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c #v5.0.0
+          with:
+            python-version-file: 'pyproject.toml'
+
+        - name: Install Python Deps
+          run: pip install openai pytest
+
+        - name: Install UDS-CLI
+          run: |
+            wget https://github.com/defenseunicorns/uds-cli/releases/download/v0.9.2/uds-cli_v0.9.2_Linux_amd64
+            chmod +x uds-cli_v0.9.2_Linux_amd64
+            sudo mv uds-cli_v0.9.2_Linux_amd64 /usr/local/bin/uds
+
+        - name: Setup K3D
+          run: |
+            wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.0 bash
+          
+        - name: Create UDS Cluster
+          run: |
+            uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-istio-dev:0.13.1 --confirm
+
+        - name: Install lfai-api 
+          run: |
+            uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai-api:v0.5.1 --confirm
+
+        # Since Zarf is slow when using local images, we are pushing the llama.cpp image to a local registry
+        - name: Build & Deploy llama.cpp
+          run: |
+            docker run -d -p 5000:5000 --restart=always --name registry registry:2
+            cp config.example.yaml config.yaml
+            docker buildx build -t localhost:5000/defenseunicorns/leapfrogai/llama-cpp-python:e2e-amd64 .
+            docker push localhost:5000/defenseunicorns/leapfrogai/llama-cpp-python:e2e-amd64 
+            uds zarf dev deploy  --registry-override=ghcr.io=localhost:5000 --create-set=IMAGE_VERSION=e2e-amd64 --no-yolo
+
+        - name: Run Tests
+          run: |
+            python -m pytest . -v

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,8 +13,7 @@ concurrency:
 
 jobs:
   e2e:
-    # runs-on: ai-ubuntu-big-boy-8-core
-    runs-on: ubuntu-latest
+    runs-on: ai-ubuntu-big-boy-8-core
      
     steps:
         - name: Checkout Repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ dependencies = ["llama-cpp-python == 0.2.28", "leapfrogai == 0.4.0"]
 
 [project.optional-dependencies]
 dev = [
-    "pip-tools",
+    "pip-tools == 7.3.0",
     "pytest",
     "black",
     "isort",
+    "openai",
+    "anyio == 3.7.1",
     "huggingface_hub[cli,hf_transfer]",
     "nvidia-cublas-cu12 == 12.3.4.1",
     "nvidia-cuda-runtime-cu12 == 12.3.101",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,13 @@
 #
 #    pip-compile --extra=dev --generate-hashes --output-file=requirements-dev.txt pyproject.toml
 #
+anyio==3.7.1 \
+    --hash=sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
+    --hash=sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5
+    # via
+    #   httpx
+    #   leapfrogai-backend-llama-cpp-py (pyproject.toml)
+    #   openai
 black==23.11.0 \
     --hash=sha256:250d7e60f323fcfc8ea6c800d5eba12f7967400eb6c2d21ae85ad31c204fb1f4 \
     --hash=sha256:2a9acad1451632021ee0d146c8765782a0c3846e0e0ea46659d7c4f89d9b212b \
@@ -31,7 +38,10 @@ build==1.0.3 \
 certifi==2024.2.2 \
     --hash=sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f \
     --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -139,6 +149,10 @@ diskcache==5.6.3 \
     --hash=sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc \
     --hash=sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
     # via llama-cpp-python
+distro==1.9.0 \
+    --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
+    --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+    # via openai
 filelock==3.13.1 \
     --hash=sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e \
     --hash=sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
@@ -214,14 +228,29 @@ grpcio-reflection==1.59.3 \
     --hash=sha256:526064089d71cddce7244a83059f410fac6ccd30344a624c10f54420d417b3d2 \
     --hash=sha256:5403c5a738c6eec4bb4080da77e450312dace41a86e292ac37cfd007b2657d4e
     # via leapfrogai
-huggingface-hub[cli,hf_transfer]==0.20.3 \
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+    # via httpcore
+httpcore==1.0.4 \
+    --hash=sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73 \
+    --hash=sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022
+    # via httpx
+httpx==0.27.0 \
+    --hash=sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5 \
+    --hash=sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5
+    # via openai
+huggingface-hub[cli,hf-transfer,hf_transfer]==0.20.3 \
     --hash=sha256:94e7f8e074475fbc67d6a71957b678e1b4a74ff1b64a644fd6cbb83da962d05d \
     --hash=sha256:d988ae4f00d3e307b0c80c6a05ca6dbb7edba8bba3079f74cda7d9c2e562a7b6
     # via leapfrogai-backend-llama-cpp-py (pyproject.toml)
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
@@ -290,6 +319,10 @@ nvidia-cublas-cu12==12.3.4.1 \
 nvidia-cuda-runtime-cu12==12.3.101 \
     --hash=sha256:04604679ddca6acb96c76a7a9306282cddc16981f92e148e2dfe227078883cda \
     --hash=sha256:8a91b2284458643233097d10887b93dc4e8085d49228e228db698ec4bcf5ac3f
+    # via leapfrogai-backend-llama-cpp-py (pyproject.toml)
+openai==1.13.3 \
+    --hash=sha256:5769b62abd02f350a8dd1a3a242d8972c947860654466171d60fb0972ae0a41c \
+    --hash=sha256:ff6c6b3bc7327e715e4b3592a923a5a1c7519ff5dd764a83d69f633d49e77a7b
     # via leapfrogai-backend-llama-cpp-py (pyproject.toml)
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
@@ -379,6 +412,7 @@ pydantic==1.10.13 \
     # via
     #   confz
     #   leapfrogai
+    #   openai
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
@@ -449,6 +483,13 @@ requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
     --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via huggingface-hub
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
+    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+    # via
+    #   anyio
+    #   httpx
+    #   openai
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
@@ -456,13 +497,16 @@ toml==0.10.2 \
 tqdm==4.66.1 \
     --hash=sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386 \
     --hash=sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7
-    # via huggingface-hub
+    # via
+    #   huggingface-hub
+    #   openai
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
     # via
     #   huggingface-hub
     #   llama-cpp-python
+    #   openai
     #   pydantic
 urllib3==2.2.0 \
     --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,40 @@
+# llama.cpp End-To-End Tests
+
+This directory holds our e2e tests that we use to verify LFAI + llama.cpp functionality in an environment that replicates a live setting. The tests in this directory are automatically run against a [UDS Core](https://github.com/defenseunicorns/uds-core) cluster whenever a PR is opened or updated.
+
+
+## Running Tests Locally
+The tests in this directory are also able to be run locally! We are currently opinionated towards running on a cluster that is configured with UDS, as we mature out tests & documentations we'll potentially lose some of that opinionation.
+
+
+### Dependencies
+1. Python >= 3.11.6
+2. k3d >= v5.6.0
+3. uds >= v0.7.0
+
+
+### Actually Running The Test
+There are several ways you can setup and run these tests. Here is one such way:
+
+```bash
+# Setup the UDS cluster
+# NOTE: This stands up a k3d cluster and installs istio & pepr
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-istio-dev:0.13.1 --confirm
+
+# Install the LFAI API
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai-api:v0.5.1 --confirm
+
+# Install the llama.cpp Backend
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+# NOTE: If you are testing changes you have made locally, you will need to rebuild the llama.cpp Docker image and Zarf Package.
+uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai/llama-cpp:v0.1.0-amd64 --confirm
+
+
+# Install the python dependencies
+python -m pip install -r requirements-dev.txt
+
+# Run the tests!
+python -m pytest .  -v
+```

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from openai import InternalServerError, OpenAI
+
+client = OpenAI(
+    base_url="https://leapfrogai-api.uds.dev/openai/v1",
+    api_key="Free the models",
+)
+
+model_name = "llama-cpp-python"
+
+
+def test_completions():
+    completion = client.completions.create(
+        model=model_name,
+        prompt="What is your name?",
+    )
+
+    assert completion.model == model_name
+    assert len(completion.choices) == 1
+    assert len(completion.choices[0].text) > 0
+    assert len(completion.choices[0].text) < 500
+
+
+def test_chat_completions():
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is your name?"},
+    ]
+
+    chat_completion = client.chat.completions.create(
+        model=model_name, messages=messages
+    )
+    assert chat_completion.model == model_name
+    assert len(chat_completion.choices) == 1
+    assert chat_completion.choices[0].message.role == "assistant"
+    assert len(chat_completion.choices[0].message.content) > 0
+    assert len(chat_completion.choices[0].message.content) < 500
+
+
+def test_embeddings():
+    with pytest.raises(InternalServerError) as excinfo:
+        client.embeddings.create(
+            model=model_name,
+            input="This should result in a failure",
+        )
+    assert str(excinfo.value) == "Internal Server Error"
+
+
+def test_transcriptions():
+    with pytest.raises(InternalServerError) as excinfo:
+        client.audio.transcriptions.create(
+            model=model_name, file=Path("tests/e2e/README.md")
+        )
+
+    assert str(excinfo.value) == "Internal Server Error"

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -2,6 +2,12 @@ package:
   create:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/llama-cpp-python"
-      image_version: 0.2.0
+      image_version: local-d24d
       name: llama-cpp-python
     max_package_size: "1000000000"
+  deploy:
+    set:
+      requests_memory: "0"
+      requests_cpu: "0"
+      limits_memory: "0"
+      limits_cpu: "0"


### PR DESCRIPTION
This PR introduces an e2e test that verifies the llama.cpp backend can be deployed onto a UDS cluster with LFAI-API and functions as expected.